### PR TITLE
fix padding calculation for column annotations with newlines

### DIFF
--- a/src/utils/images_grid.py
+++ b/src/utils/images_grid.py
@@ -109,7 +109,7 @@ def _create_grid_annotation(
             + font.getlength(WIDEST_LETTER)*2
         )
     if column_texts:
-        top_padding = int(font.size * 2)
+        top_padding = max(col_text.count('\n') for col_text in column_texts) * int(font.size) + int(font.size * 2)
 
     image = Image.new(
         "RGB",


### PR DESCRIPTION
Currently only the row calculation accounts for newlines in the annotation text, if there are newlines in the column annotations they will overflow into the image. This change fixes that by counting how many newlines there are and increasing the padding to account for that.